### PR TITLE
feat: create route handler (POST) for sending user game data

### DIFF
--- a/src/app/play/data/tideLevel.js
+++ b/src/app/play/data/tideLevel.js
@@ -1,4 +1,5 @@
-const tideLevel = {
+const tideLevel =
+    {
     // hiragana
     "あ": 5,
     "い": 4,

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -30,7 +30,7 @@ const Play = () => {
         totalScore += characterScore});
         return totalScore;
     }
-    const totalScore = getTotalScore(kanaScore);
+    const totalScore = getTotalScore(kanaScore) // totalScore is a derived state from kanaScore
 
     const generateQuestion = (): string => {
         const randomIndex = Math.floor(Math.random() * questionPool.length);
@@ -46,10 +46,20 @@ const Play = () => {
         }
     }, [questionPool])
 
+    const saveScore = async () => {
+        //  POST data to DB via route handlers here
+        const res = await fetch('/play/sendScore/', { method: 'POST'});
+        console.log(res);
+
+    }
+
     if (session && session.user) {
         // Logged in state
         return (
             <>
+                <button onClick={saveScore}>
+                    save score~
+                </button>
             <p>
                 Question Filter
                 <br />

--- a/src/app/play/sendScore/route.ts
+++ b/src/app/play/sendScore/route.ts
@@ -1,0 +1,24 @@
+import {connectDB, updateCurrentUser} from "@/utils/database";
+import {NextResponse} from "next/server";
+
+export const dynamic = 'force-dynamic';
+export async function POST() {
+    console.log("hello you have posted")
+    await connectDB();
+
+    await updateCurrentUser('64e7a35bf3b19fa4448640e4');
+    //
+    // const res = await fetch('theURL', {
+    //  method: 'POST',
+    //  headers: {
+    //      'Content-Type': 'application/json',
+    //      'API-Key': process.env.DB_CONNECTION_STRING!,
+    //  },
+    //  // connect to the DB
+    //  body: JSON.stringify(1234), // whatever the score is
+    // }) // the mongoDB api URL
+
+    // return Response.json(res)
+    return NextResponse.json({ message: "This Worked", success: true });
+
+}

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,6 +1,6 @@
 import { Schema, model, models } from 'mongoose';
 import {userIceCreamStackSchema} from "@/models/userIceCreamStack";
-import {userTideLevelSchema} from "@/models/userTideLevel";
+import userTideLevel, {userTideLevelSchema} from "@/models/userTideLevel";
 
 const UserSchema = new Schema({
     email: {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -16,7 +16,7 @@ const UserSchema = new Schema({
         type: String,
     },
     iceCreamStack: [userIceCreamStackSchema],
-    tideLevel: userTideLevelSchema,
+    tideLevel: [userTideLevelSchema],
     unlockedIceCreams: [
         {
             iceCream: {

--- a/src/models/userTideLevel.ts
+++ b/src/models/userTideLevel.ts
@@ -1,9 +1,9 @@
-import { Schema, model, models } from "mongoose";
+import mongoose, { Schema, model, models } from "mongoose";
 
 export const userTideLevelSchema = new Schema({
     kana: String,
-    tideLevel: Number,
-},
+    level: Number,
+    }
 );
 
 const userTideLevel = models.userTideLevel || model('userTideLevel', userTideLevelSchema);

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -24,9 +24,9 @@ export const updateCurrentUser = async (currentUserId: string) => {
         const userId = user._id;  // get user ID
         console.log(userId, 'the userId');
         await addInitialTideLevelForUser(userId);
-        const clonedTideLevel = { kana: "ら", level: 3 };
-        console.log(clonedTideLevel, 'clonedTideLevel before update');
-        // const clonedTideLevel = { ...tideLevel };
+        const clonedTideLevel = Object.entries(tideLevel).map(([ kana, level]) => {
+            return { kana, level };
+        });
         const clonedInitialIceCreamStack = [...initialIceCreamStack];
         await User.updateOne(
             { _id: userId },

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -24,7 +24,9 @@ export const updateCurrentUser = async (currentUserId: string) => {
         const userId = user._id;  // get user ID
         console.log(userId, 'the userId');
         await addInitialTideLevelForUser(userId);
-        const clonedTideLevel = { ...tideLevel };
+        const clonedTideLevel = { kana: "ら", level: 3 };
+        console.log(clonedTideLevel, 'clonedTideLevel before update');
+        // const clonedTideLevel = { ...tideLevel };
         const clonedInitialIceCreamStack = [...initialIceCreamStack];
         await User.updateOne(
             { _id: userId },

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -22,6 +22,7 @@ export const updateCurrentUser = async (currentUserId: string) => {
             return;
         }
         const userId = user._id;  // get user ID
+        console.log(userId, 'the userId');
         await addInitialTideLevelForUser(userId);
         const clonedTideLevel = { ...tideLevel };
         const clonedInitialIceCreamStack = [...initialIceCreamStack];
@@ -44,6 +45,9 @@ export const updateCurrentUser = async (currentUserId: string) => {
                 },
             }
         );
+        console.log(clonedTideLevel, 'clonedTideLevel')
+        console.log('ok update for this user is supposedly done!')
+
     } catch (error) {
         console.log('An error occurred:', error);
     }


### PR DESCRIPTION
## Objective: 
- Send tideLevel.js object to mongoDB back end

## Issue:
- tideLevel is organised in this way:
```
const tideLevel =
    {
    // hiragana
    "あ": 5,
    "い": 4,
    "う": 3,
    "え": 2,
    "お": 1,
    "か": 5, ...and so on 
```

but when we send this object as-is to mongoDB, the object is not recognised and only an `_id` is added to the document.
![image](https://github.com/sheleoni/icecream-kana-game/assets/85994674/c882778d-470a-4768-85a8-bbf956ba5a25)
([ref](https://github.com/sheleoni/icecream-kana-game/pull/57#issuecomment-1848873574))

## Solution
Settled for now, documented [here](https://github.com/sheleoni/icecream-kana-game/pull/57#issuecomment-1853701865).
